### PR TITLE
Typo: [Integtated] File systems

### DIFF
--- a/index.html
+++ b/index.html
@@ -304,7 +304,7 @@
 						<div class="col-md-6 col-xs-12">
 							<div class="service-item">
 								<i class="tf-puzzle"></i>
-								<h3>Integtated File systems</h3>
+								<h3>Integrated File Systems</h3>
 								<p>Easily bring files and source code between the host Mac and Guest OS&#39;s or Containers</p>
 							</div>
 						</div>


### PR DESCRIPTION
Fixed typo [Integtated] to Integrated. Also capitalized [File systems] for consistency.